### PR TITLE
fixed bug in dcg learner

### DIFF
--- a/src/config/algs/dicg.yaml
+++ b/src/config/algs/dicg.yaml
@@ -1,5 +1,6 @@
 # --- DICG specific parameters ---
 name: "dicg"
+is_masssge: True
 
 # use epsilon greedy action selector
 action_selector: "epsilon_greedy"

--- a/src/learners/dcg_learner.py
+++ b/src/learners/dcg_learner.py
@@ -17,10 +17,11 @@ class DCGLearner(QLearner):
             self.action_encoder_optimiser = RMSprop(params=self.action_encoder_params, lr=args.lr, alpha=args.optim_alpha, eps=args.optim_eps)
             self.action_repr_updating = True
 
-    def train(self, batch: EpisodeBatch, t_env: int, episode_num: int):
+    def train(self, episode_sample: EpisodeBatch, max_ep_t, t_env: int, episode_num: int):
         """ Overrides the train method from QLearner. """
 
         # Get the relevant quantities
+        batch = episode_sample[:, :max_ep_t]
         rewards = batch["reward"][:, :-1]
         actions = batch["actions"][:, :-1]
         terminated = batch["terminated"][:, :-1].float()

--- a/src/main.py
+++ b/src/main.py
@@ -54,7 +54,7 @@ def _get_config(params, arg_name, subfolder):
 
 def recursive_dict_update(d, u):
     for k, v in u.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, collections.abc.Mapping):
             d[k] = recursive_dict_update(d.get(k, {}), v)
         else:
             d[k] = v


### PR DESCRIPTION
Fixed bugs: 

1. `def train(self, batch: EpisodeBatch, t_env: int, episode_num: int):` 

needs to be the following (same update to Pymarl's version as what has been done for other learners here too):

```
def train(self, episode_sample: EpisodeBatch, max_ep_t, t_env: int, episode_num: int):
        """ Overrides the train method from QLearner. """ 
        # Get the relevant quantities
        batch = episode_sample[:, :max_ep_t]
```

2. fixed "missing is_masssge" in dicg.yaml config 
3. `collections.Mapping` --> `collections.abc.Mapping`